### PR TITLE
Correct lodash package name in test fixture

### DIFF
--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,5 +1,5 @@
-var _clone  = require( 'lodash/lang/cloneDeep' );
-var _assign = require( 'lodash/object/assign' );
+var _clone  = require( 'lodash-compat/lang/cloneDeep' );
+var _assign = require( 'lodash-compat/object/assign' );
 
 module.exports.args = {
     carousel: 'carousel',


### PR DESCRIPTION
Corrects lodash package name in test fixture import statement from `lodash/...` -> `lodash-compat/...` to match installed package
